### PR TITLE
Bump version of VGL and adds helper scripts

### DIFF
--- a/Recipes/BLENDER_LUMI.def
+++ b/Recipes/BLENDER_LUMI.def
@@ -2,13 +2,16 @@ Bootstrap: oras
 from: ghcr.io/lumi-supercomputer/vgl:1.0
 
 %post
-    BLENDER_VERSION=3.5.1
-    
+    BLENDER_VERSION=3.5.1 
+    zypper -n install libxkbcommon0
     wget https://ftp.halifax.rwth-aachen.de/blender/release/Blender$(cut -d . -f1-2 <<< $BLENDER_VERSION)/blender-$BLENDER_VERSION-linux-x64.tar.xz
     tar xf blender-$BLENDER_VERSION-linux-x64.tar.xz
     mv blender-$BLENDER_VERSION-linux-x64 /opt/blender
     rm blender-$BLENDER_VERSION-linux-x64.tar.xz
 %runscript
-    bus_id=$(nvidia-smi --query-gpu=gpu_bus_id --format=csv,noheader)
-    export VGL_DISPLAY="/dev/dri/$(basename $( ls -d /sys/bus/pci/devices/${bus_id: -12}/drm/card* ))"
-    vglrun /opt/blender/blender
+    export VGL_DISPLAY=$(getEglCard)
+    if [[ ! -e $VGL_DISPLAY ]]; then
+        eglDebugInfo
+    else
+        vglrun /opt/blender/blender
+    fi

--- a/Recipes/PARAVIEW_LUMI.def
+++ b/Recipes/PARAVIEW_LUMI.def
@@ -6,21 +6,9 @@ from: ghcr.io/lumi-supercomputer/vgl:1.0
     cp /usr/bin/true /usr/sbin/useradd
     zypper -n install paraview
 %runscript
-    bus_id=$(nvidia-smi --query-gpu=gpu_bus_id --format=csv,noheader)
-    bus_id_lower=${bus_id,,}
-    if ls -d /sys/bus/pci/devices/${bus_id: -12}/drm/card* ; then
-        export VGL_DISPLAY="/dev/dri/$(basename $( ls -d /sys/bus/pci/devices/${bus_id: -12}/drm/card* ))"
-    elif ls -d /sys/bus/pci/devices/${bus_id_lower: -12}/drm/card* ;then 
-        export VGL_DISPLAY="/dev/dri/$(basename $( ls -d /sys/bus/pci/devices/${bus_id_lower: -12}/drm/card* ))"
+    export VGL_DISPLAY=$(getEglCard)
+    if [[ ! -e $VGL_DISPLAY ]]; then
+        eglDebugInfo
     else
-        echo "Internal error failed to find a GPU for VGL, here is some info"
-        echo "Some information:"
-        echo "HOST $(hostname)"
-        echo "NVIDIA SMI OUTPUT"
-        nvidia-smi
-        echo "Container recipe"
-        cat /.singularity.d/Singularity
-        echo "Press any key to exit"
-        read  -n 1 
+        vglrun paraview
     fi
-    vglrun paraview

--- a/Recipes/VGL_LUMI.def
+++ b/Recipes/VGL_LUMI.def
@@ -33,6 +33,8 @@ From: ghcr.io/lumi-supercomputer/vnc:1.0
     cat /.singularity.d/Singularity
     echo "======================================================="
     ' > /usr/bin/eglDebugInfo
+    chmod +x /usr/bin/getEglCard /usr/bin/eglDebugInfo
+
 
 
     rpm -i /VirtualGL-${VGL_VERSION}.x86_64.rpm

--- a/Recipes/VGL_LUMI.def
+++ b/Recipes/VGL_LUMI.def
@@ -2,20 +2,42 @@ Bootstrap: oras
 From: ghcr.io/lumi-supercomputer/vnc:1.0
 
 %post
-    VGL_VERSION=3.0.2
-    NVIDIA_DRIVER_VERSION=525.125.06
 
+    VGL_VERSION=3.1
+    NVIDIA_DRIVER_VERSION=525.125.06
     cd /
+
     wget -O VirtualGL-${VGL_VERSION}.x86_64.rpm https://sourceforge.net/projects/virtualgl/files/${VGL_VERSION}/VirtualGL-${VGL_VERSION}.x86_64.rpm/download
-    zypper -n install libXv1
-    zypper -n install Mesa-libGL1
-    zypper -n install Mesa-libEGL1 libGLU1
+    zypper -n install libXv1 libjson-c3 libturbojpeg0
+    zypper -n install Mesa-libGL1 Mesa-libEGL1 libGLU1
     zypper -n install libglvnd libglvnd-devel
-    zypper -n install xorg-x11-xauth xterm libXtst6
-    zypper -n install xorg-x11-fonts
+    zypper -n install xorg-x11-xauth xterm libXtst6 xorg-x11-fonts
     zypper -n install kmod
+
+    echo "#!/bin/bash
+    tee /dev/dri/card* 2>&1<<<0 | grep I | cut -d ':' -f2 | tr -d ' ' | head -n1
+    " > /usr/bin/getEglCard
+
+    echo '#!/bin/bash
+    echo "Internal error, failed to get GPU card for EGL"
+    echo "HOST: $(hostname)"
+    echo "NVIDIA SMI: $(nvidia-smi)"
+    echo "Container: $SINGULARITY_CONTAINER"
+    echo "JobId: $SLURM_JOB_ID"
+    echo -e "SLURM_STEP_GPUS:$SLURM_STEP_GPUS\nSLURM_GPUS_ON_NODE:$SLURM_GPUS_ON_NODE\nGPU_DEVICE_ORDINAL:$GPU_DEVICE_ORDINAL"
+    echo "================ /dev/dri/ Permissions ================"
+    ls -la /dev/dri/
+    echo "================ /dev/dri Device test ================="
+    tee /dev/dri/card* 2>&1<<<0
+    echo "================ Container recipe ====================="
+    cat /.singularity.d/Singularity
+    echo "======================================================="
+    ' > /usr/bin/eglDebugInfo
+
+
     rpm -i /VirtualGL-${VGL_VERSION}.x86_64.rpm
+
     wget https://us.download.nvidia.com/tesla/${NVIDIA_DRIVER_VERSION}/NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}.run
     sh NVIDIA-Linux-x86_64-${NVIDIA_DRIVER_VERSION}.run -a -N --ui=none --no-kernel-module --no-x-check
-    zypper -n install libturbojpeg0
+
     vglserver_config +s +f +t +glx


### PR DESCRIPTION
Update the VGL version to 3.1
And adds two helper scripts to the container.
One for getting the correct `/dev/dri/card<num>` for use with EGL, and another for printing debug information.