### PR TITLE
Use nvidia-smi for identifying correct GPU

### DIFF
--- a/Recipes/VGL_LUMI.def
+++ b/Recipes/VGL_LUMI.def
@@ -4,7 +4,7 @@ From: ghcr.io/lumi-supercomputer/vnc:1.0
 %post
 
     VGL_VERSION=3.1
-    NVIDIA_DRIVER_VERSION=525.125.06
+    NVIDIA_DRIVER_VERSION=535.216.01
     cd /
 
     wget -O VirtualGL-${VGL_VERSION}.x86_64.rpm https://sourceforge.net/projects/virtualgl/files/${VGL_VERSION}/VirtualGL-${VGL_VERSION}.x86_64.rpm/download
@@ -14,9 +14,19 @@ From: ghcr.io/lumi-supercomputer/vnc:1.0
     zypper -n install xorg-x11-xauth xterm libXtst6 xorg-x11-fonts
     zypper -n install kmod
 
-    echo "#!/bin/bash
-    tee /dev/dri/card* 2>&1<<<0 | grep I | cut -d ':' -f2 | tr -d ' ' | head -n1
-    " > /usr/bin/getEglCard
+    echo '#!/bin/bash
+    output=$(timeout 5 nvidia-smi --query-gpu=gpu_bus_id --format=csv,noheader)
+    exit_code=$?
+    if [ "$exit_code" -ne 0 ]; then
+      >&2 echo "nvidia-smi exited with status $exit_code: $output"
+      exit 1
+    fi
+
+    card=$(echo "$output" | cut -c 5- | tr "[:upper:]" "[:lower:]")
+    card_path="/dev/dri/by-path/pci-$card-card"
+    [ -e "$card_path" ] || >&2 echo "$card_path does not exist"
+    readlink -e "$card_path"
+    ' > /usr/bin/getEglCard
 
     echo '#!/bin/bash
     echo "Internal error, failed to get GPU card for EGL"


### PR DESCRIPTION
Use nvidia-smi for identifying correct GPU since the previous method does not work right now.